### PR TITLE
Fix the behavior of repeatable options determination

### DIFF
--- a/docoptcfg.py
+++ b/docoptcfg.py
@@ -73,6 +73,8 @@ def settable_options(doc, argv, ignore, options_first):
                 continue  # Don't care about this if we can't set it.
             if getattr(option, 'long') in booleans and getattr(option, 'value') == 0:
                 repeatable.add(getattr(option, 'long'))
+            elif isinstance(getattr(option, 'value'), str):
+                continue  # Check manually the type because strings are iterable
             elif hasattr(getattr(option, 'value'), '__iter__'):
                 repeatable.add(getattr(option, 'long'))
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -12,3 +12,34 @@ def test_no_settable():
     expected['--flag'] = 1
     expected['--key'] = ['val']
     assert actual == expected
+
+
+def test_issue_7(monkeypatch, tmpdir):
+    """Test to cover the issue [#7](https://github.com/Robpol86/docoptcfg/issues/7)"""
+
+    docstring = """\
+    Test to reproduce #7
+    
+    Usage:
+        my_script [--key=VAL] [--env=ENV] [--config=FILE] <pos>...
+        
+    Options:
+        --config=FILE  Path INI config file.
+        --key=VAL      Key value [default: some_value]
+        --env=ENV      Env value [default: some_env]
+    """
+
+    config_file = tmpdir.join('config.ini')
+    config_file.write('[my_script]\nkey = another_value')
+
+    expected = {
+        '--config': str(config_file),
+        '--key': 'another_value',
+        '--env': 'another_env',
+        '<pos>': ['1']
+    }
+
+    monkeypatch.setattr('sys.argv', ['my_script', '--config', str(config_file), '1'])
+    monkeypatch.setenv('TEST_ENV', 'another_env')
+    actual = docoptcfg(docstring, config_option='--config', env_prefix='TEST_')
+    assert actual == expected


### PR DESCRIPTION
Since Python 3, the function `__iter__` has been added to the string
objects. Which means the wrapper can consider as repeatable a non
repeatable option. The issue occurs if the docstring has an option with
a default valeu and at least another repeatable option. See #7 for more
details.

Fix the issue by type checking the default value to check if it's a
string before checking if it's iterable. It doesn't respect the duck
typing principal, but I believe for this particular case, it won't
matter.

Fix #7